### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Install [Azure CLI](https://aka.ms/azure-cli), and Login into your Azure account
 az login
 ```
 
-Then selcet an available subscription from your account.
+Then select an available subscription from your account.
 
 
 ## Environment Variables


### PR DESCRIPTION
## Summary
- fix a typo in README regarding Azure CLI instructions

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6889e3361004832ab432af8de264040a